### PR TITLE
👕 Remove lint rules, add --fix flag to lint command

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "lint": "eslint src -c .eslintrc.json --ext js",
+    "lint": "eslint --fix src -c .eslintrc.json --ext js",
     "test": "echo \"Test not created yet\" && exit 0"
   },
   "dependencies": {

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -11,6 +11,8 @@
   ],
   "plugins": ["react", "prettier", "flowtype"],
   "rules": {
+    "react/destructuring-assignment": [0],
+    "react/prefer-stateless-function": [0],
     "react/jsx-filename-extension": [
       1,
       {

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "lint": "eslint src -c .eslintrc.json --ext js,jsx",
+    "lint": "eslint --fix src -c .eslintrc.json --ext js,jsx",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
This pull request:
- Disables the [destructuring-assigment](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md) lint rule
- Disables the [prefer-stateless-function](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md) lint rule
- Adds `--fix` to lint command in both api and client package.json