### PR TITLE
🙀 Add endpoints to post and get category, only surface get to client

### DIFF
--- a/api/src/api/category.js
+++ b/api/src/api/category.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const { errorWrap } = require('../middleware');
+const Category = require('../models/category');
+
+// Get all categories
+router.get(
+  '/',
+  errorWrap(async (req, res) => {
+    const categories = await Category.find();
+    res.json({
+      code: 200,
+      message: '',
+      success: true,
+      result: categories,
+    });
+  }),
+);
+
+// Create a new category
+router.post(
+  '/',
+  errorWrap(async (req, res) => {
+    const newCategory = new Category(req.body);
+    await newCategory.save();
+    res.status(201).json({
+      code: 201,
+      message: `Successfully created new category ${newCategory.id}`,
+      success: true,
+      result: newCategory,
+    });
+  }),
+);
+
+module.exports = router;

--- a/api/src/api/index.js
+++ b/api/src/api/index.js
@@ -1,5 +1,7 @@
+const category = require('./category');
 const resource = require('./resource');
 
 module.exports = {
+  category,
   resource,
 };

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -1,12 +1,9 @@
 const express = require('express');
 
 const router = express.Router();
-const { resource } = require('../api');
+const { category, resource } = require('../api');
 
-router.get('/', (req, res) => {
-  res.send('hi');
-});
-
+router.use('/api/categories', category);
 router.use('/api/resources', resource);
 
 module.exports = router;

--- a/api/src/routes/testAPI.js
+++ b/api/src/routes/testAPI.js
@@ -1,8 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-router.get('/', function(req, res, next) {
-  res.send('YMCA API is working properly!');
-});
-
-module.exports = router;

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -4,6 +4,10 @@ const instance = axios.create({
   baseURL: 'http://localhost:9000',
 });
 
+export const getCategories = () => {
+  return instance.get('/api/categories').then(res => res.data, err => null);
+}
+
 export const getResources = () => {
   return instance.get('/api/resources').then(res => res.data, err => null);
 };


### PR DESCRIPTION
This PR adds two endpoints to GET all categories and POST a category.
I only surfaced the GET request to the client, as we do not currently have a use case for the client to POST.  The POST is more for internal testing uses now.

Tested both endpoints with postman.