### PR TITLE
🔄 Routes all resources to /resources

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -75,7 +75,7 @@ export default class Home extends Component {
             </Textfit>
             <Row type="flex" justify="center" align="middle" gutter={[16, 16]}>
               <Col span={18}>
-                <Link to="/resources?category=All Resources">
+                <Link to="/resources">
                   <Button type="primary">
                     <strong>Find Resources</strong>
                   </Button>

--- a/client/src/components/Navigation.js
+++ b/client/src/components/Navigation.js
@@ -25,7 +25,7 @@ const Navigation = (props: Props) => {
           <a href="/">YMCA</a>
         </Menu.Item>
         <Menu.Item key="resources">
-          <a href="/resources?category=All Resources">Resources</a>
+          <a href="/resources">Resources</a>
         </Menu.Item>
 
         {authed && (

--- a/client/src/components/Resources.js
+++ b/client/src/components/Resources.js
@@ -59,6 +59,11 @@ export default class Resources extends Component<Props, State> {
 
   getCategorySelectedFromSearch() {
     const { search } = this.props.location;
+    
+    if (search === '') {
+      return ['All Resources', ''];
+    }
+
     const subcategoryIndex = search.indexOf('&');
     let categorySelected = search.slice(
       search.indexOf('=') + 1,
@@ -104,7 +109,6 @@ export default class Resources extends Component<Props, State> {
   categorySelectAll = async () => {
     this.props.history.push({
       pathname: '/resources',
-      search: `?category=All Resources`,
     });
   };
 

--- a/client/src/components/ResourcesBreadcrumb.js
+++ b/client/src/components/ResourcesBreadcrumb.js
@@ -13,7 +13,7 @@ function ResourcesBreadcrumb(props) {
     breadcrumbs.push(<span>All Resources</span>);
   } else if (categorySelected !== '') {
     breadcrumbs.push(
-      <Link className="link" to="resources?category=All Resources">
+      <Link className="link" to="resources">
         <span>All Resources</span>
       </Link>,
     );


### PR DESCRIPTION
This PR:
* Changes the routing so all resources is now routed to /resources rather than /resources=All%20Resources
* Tested by navigating to all resources via navbar, home page, breadcrumbs, and filter sidebar
* Resolves #42 