### PR TITLE
🐛 Fix website being undefined in resource detail

### DIFF
--- a/api/src/api/admin.js
+++ b/api/src/api/admin.js
@@ -67,4 +67,19 @@ router.post(
   }),
 );
 
+// Delete a category
+router.delete(
+  '/categories/:id',
+  errorWrap(async (req, res) => {
+    const { id } = req.params;
+    await Category.findByIdAndDelete(id);
+    res.json({
+      code: 200,
+      message: `Successfully deleted category ${id}`,
+      success: true,
+      result: null,
+    });
+  }),
+);
+
 module.exports = router;

--- a/api/src/models/resource.js
+++ b/api/src/models/resource.js
@@ -17,12 +17,12 @@ const FinancialAid = new mongoose.Schema({
   education: { type: String, required: false },
   immigrationStatus: { type: String, required: false },
   deadline: { type: String, required: false },
-  amount: {type: String, required: false},
+  amount: { type: String, required: false },
 });
 
 const InternalNote = new mongoose.Schema({
-  subject: {type: String, required: true},
-  body: {type: String, required: true},
+  subject: { type: String, required: true },
+  body: { type: String, required: true },
 });
 
 const Resource = new mongoose.Schema({

--- a/client/src/components/ResourceDetail.js
+++ b/client/src/components/ResourceDetail.js
@@ -55,7 +55,7 @@ export default class ResourceDetail extends Component {
         languages: result.availableLanguages,
         category: result.category[0],
         subcategory: result.subcategory[0],
-        website: result.website,
+        website: result.website || '',
         eligibility: result.eligibilityRequirements,
       });
     } else {


### PR DESCRIPTION
This PR:
* Adds a check for if the website is undefined in a resource (aka not entered in the database), and sets it to an empty string if so
    * This was causing the issue where the resource detail page would not load
* Adds a `DELETE category` admin endpoint
    * I used this to delete a duplicate "treatment" category that was showing up in the resource creation admin form
