### PR TITLE
🐛 Fix build step

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "react-scripts start",
     "lint": "eslint --fix src -c .eslintrc.json --ext js,jsx",
-    "build": "react-scripts build",
+    "build": "CI=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "flow": "flow"


### PR DESCRIPTION
For unknown reasons it broke because CI=true, so this sets it to false.