### PR TITLE
🧹 Clean up auth code [PART 2]

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -28,7 +28,7 @@ import ResourceDetailCommon from './components/ResourceDetailCommon';
 import { useAuth } from './utils/use-auth';
 
 const App = () => {
-  const { authed, authRoleIsEquivalentTo, setAuthed, setAuthRole } = useAuth();
+  const { authed, authRoleIsEquivalentTo } = useAuth();
 
   const showIfUnauthed = useCallback(
     component => {
@@ -53,108 +53,56 @@ const App = () => {
     <>
       <Router>
         <ScrollToTop />
-        <Navigation
-          authed={authed}
-          authRoleIsEquivalentTo={authRoleIsEquivalentTo}
-        />
+        <Navigation />
         <Switch>
           <Route path="/" exact component={Home} />
           <PrivateRoute
             path="/admin"
             component={AdminResourceManager}
             exact
-            authed={authed}
-            authRoleIsEquivalentTo={authRoleIsEquivalentTo}
             minRole="admin"
           />
           <PrivateRoute
             path="/admin/:id"
             component={AdminResourceManager}
-            authed={authed}
-            authRoleIsEquivalentTo={authRoleIsEquivalentTo}
             minRole="admin"
           />
           <PrivateRoute
             path="/edit-home"
             component={EditHome}
             exact
-            authed={authed}
-            authRoleIsEquivalentTo={authRoleIsEquivalentTo}
             minRole="admin"
           />
 
           <Route
             path="/saved"
-            render={props => <SavedResources {...props} authed={authed} />}
+            render={props => <SavedResources {...props} />}
           />
 
-          <Route
-            path="/login"
-            render={() =>
-              showIfUnauthed(
-                <Login
-                  authed={authed}
-                  setAuthed={setAuthed}
-                  setAuthRole={setAuthRole}
-                />,
-              )
-            }
-          />
+          <Route path="/login" render={() => showIfUnauthed(<Login />)} />
 
-          <Route
-            path="/register"
-            render={() =>
-              showIfUnauthed(
-                <Register
-                  authed={authed}
-                  setAuthed={setAuthed}
-                  setAuthRole={setAuthRole}
-                />,
-              )
-            }
-          />
+          <Route path="/register" render={() => showIfUnauthed(<Register />)} />
 
           <Route
             path="/password-reset"
-            render={() =>
-              showIfUnauthed(
-                <PasswordReset
-                  authed={authed}
-                  setAuthed={setAuthed}
-                  setAuthRole={setAuthRole}
-                />,
-              )
-            }
+            render={() => showIfUnauthed(<PasswordReset />)}
           />
 
-          <Route
-            path="/logout"
-            render={() => (
-              <Logout setAuthed={setAuthed} setAuthRole={setAuthRole} />
-            )}
-          />
+          <Route path="/logout" render={() => <Logout />} />
           <Route
             path="/resources"
             exact
-            render={props => <Resources {...props} authed={authed} />}
+            render={props => <Resources {...props} />}
           />
           <Route path="/resources/unknown" component={ResourceUnknown} />
           <PrivateRoute
             path="/role-approval"
             component={RoleApproval}
-            authed={authed}
-            authRoleIsEquivalentTo={authRoleIsEquivalentTo}
             minRole="admin"
           />
           <Route
             path="/resources/:id"
-            render={props => (
-              <ResourceDetailCommon
-                {...props}
-                authed={authed}
-                authRoleIsEquivalentTo={authRoleIsEquivalentTo}
-              />
-            )}
+            render={props => <ResourceDetailCommon {...props} />}
           />
           <Route component={NotFound} />
         </Switch>

--- a/client/src/components/Navigation.js
+++ b/client/src/components/Navigation.js
@@ -7,30 +7,10 @@ import useWindowDimensions from '../utils/mobile';
 import NavMobile from './mobile/NavigationMobile';
 import NavDesktop from './desktop/NavigationDesktop';
 
-type Props = {
-  authed: Boolean,
-  authRoleIsEquivalentTo: String => void,
-};
-
-const Navigation = (props: Props) => {
-  const { authed, authRoleIsEquivalentTo } = props;
-
+const Navigation = () => {
   const isMobile = useWindowDimensions()[1];
 
-  const desktop = (
-    <NavDesktop
-      authed={authed}
-      authRoleIsEquivalentTo={authRoleIsEquivalentTo}
-    />
-  );
-  const mobile = (
-    <NavMobile
-      authed={authed}
-      authRoleIsEquivalentTo={authRoleIsEquivalentTo}
-    />
-  );
-
-  return isMobile ? mobile : desktop;
+  return isMobile ? <NavMobile /> : <NavDesktop />;
 };
 
 export default Navigation;

--- a/client/src/components/PrivateRoute.js
+++ b/client/src/components/PrivateRoute.js
@@ -3,20 +3,21 @@
 import * as React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 
+import { useAuth } from '../utils/use-auth';
+
 type Props = {
   minRole: string,
   path: string,
   component: React.ComponentType<any>,
-  authed: ?boolean,
-  authRoleIsEquivalentTo: string => ?boolean,
 };
 
 const PrivateRoute = (props: Props) => {
-  const { minRole, path, component, authed, authRoleIsEquivalentTo } = props;
+  const { authed, authRoleIsEquivalentTo } = useAuth();
+  const { minRole, path, component } = props;
 
   const equivalent = authRoleIsEquivalentTo(minRole);
 
-  if (authed && equivalent) {
+  if (authed === true && equivalent === true) {
     return <Route path={path} exact component={component} />;
   }
 

--- a/client/src/components/ResourcePreview.js
+++ b/client/src/components/ResourcePreview.js
@@ -21,7 +21,6 @@ function ResourcePreview(props) {
     name,
     subcategory,
     isSaved,
-    authed,
     updateSaved,
     image,
   } = props;
@@ -98,7 +97,6 @@ function ResourcePreview(props) {
               <div className="resource-preview-name">{name}</div>
               <div style={{ float: 'right' }}>
                 <SaveButton
-                  authed={authed}
                   isSaved={isSaved}
                   deleteResourceHandler={deleteResourceHandler}
                   saveResourceHandler={saveResourceHandler}
@@ -123,7 +121,6 @@ ResourcePreview.propTypes = {
   name: PropTypes.string.isRequired,
   subcategory: PropTypes.arrayOf(PropTypes.string).isRequired,
   isSaved: PropTypes.bool.isRequired,
-  authed: PropTypes.bool.isRequired,
   updateSaved: PropTypes.func.isRequired,
   image: PropTypes.string.isRequired,
 };

--- a/client/src/components/ResourcesGrid.js
+++ b/client/src/components/ResourcesGrid.js
@@ -6,7 +6,7 @@ import ResourcePreview from './ResourcePreview';
 import '../css/ResourcesGrid.css';
 
 function ResourcesGrid(props) {
-  const { filteredResources, savedResources, authed, updateSaved } = props;
+  const { filteredResources, savedResources, updateSaved } = props;
 
   const cards = Array(Math.ceil(filteredResources.length / 3))
     .fill()
@@ -34,7 +34,6 @@ function ResourcesGrid(props) {
               name={first.name}
               subcategory={first.subcategory}
               isSaved={savedResources.has(first._id)}
-              authed={authed}
               updateSaved={updateSaved}
               image={first.image || ''}
             />
@@ -51,7 +50,6 @@ function ResourcesGrid(props) {
                 name={second.name}
                 subcategory={second.subcategory}
                 isSaved={savedResources.has(second._id)}
-                authed={authed}
                 updateSaved={updateSaved}
                 image={second.image || ''}
               />
@@ -69,7 +67,6 @@ function ResourcesGrid(props) {
                 name={third.name}
                 subcategory={third.subcategory}
                 isSaved={savedResources.has(third._id)}
-                authed={authed}
                 updateSaved={updateSaved}
                 image={third.image || ''}
               />
@@ -96,7 +93,6 @@ ResourcesGrid.propTypes = {
     }),
   ).isRequired,
   savedResources: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-  authed: PropTypes.bool.isRequired,
   updateSaved: PropTypes.func.isRequired,
 };
 

--- a/client/src/components/SaveButton.js
+++ b/client/src/components/SaveButton.js
@@ -6,9 +6,9 @@ import { Button, Popover } from 'antd';
 import { HeartOutlined, HeartFilled } from '@ant-design/icons';
 
 import '../css/SaveButton.css';
+import { useAuth } from '../utils/use-auth';
 
 type SaveButtonProps = {
-  authed: Boolean,
   isSaved: Boolean,
   fullButton: Boolean,
   deleteResourceHandler: () => void,
@@ -16,8 +16,8 @@ type SaveButtonProps = {
 };
 
 function SaveButton(props: SaveButtonProps) {
+  const { authed } = useAuth();
   const {
-    authed,
     isSaved,
     fullButton,
     deleteResourceHandler,

--- a/client/src/components/desktop/NavigationDesktop.js
+++ b/client/src/components/desktop/NavigationDesktop.js
@@ -5,15 +5,12 @@ import { Layout, Menu } from 'antd';
 import '../../css/Navigation.css';
 import { NavLink } from 'react-router-dom';
 
+import { useAuth } from '../../utils/use-auth';
+
 const { Header } = Layout;
 
-type Props = {
-  authed: Boolean,
-  authRoleIsEquivalentTo: String => void,
-};
-
-const NavDesktop = (props: Props) => {
-  const { authed, authRoleIsEquivalentTo } = props;
+const NavDesktop = () => {
+  const { authed, authRoleIsEquivalentTo } = useAuth();
 
   return (
     <Header className="navigation">

--- a/client/src/components/desktop/ResourceDetail.js
+++ b/client/src/components/desktop/ResourceDetail.js
@@ -23,12 +23,15 @@ import {
 import ResourcesBreadcrumb from '../ResourcesBreadcrumb';
 import SaveButton from '../SaveButton';
 import ShareButton from '../ShareButton';
+import { useAuth } from '../../utils/use-auth';
 
 import '../../css/ResourceDetail.css';
 
 const { Header } = Layout;
 
 function ResourceDetail(props) {
+  const { authed, authRoleIsEquivalentTo } = useAuth();
+
   const [name, setName] = useState('Resource Name');
   const [phone, setPhone] = useState([]);
   const [address, setAddress] = useState('');
@@ -101,7 +104,7 @@ function ResourceDetail(props) {
         setFinancialAidDetails(result.financialAidDetails);
         setContacts(result.contacts);
 
-        if (props.authed) {
+        if (authed) {
           let savedSet = new Set();
           const json = await getSavedResources();
           savedSet = new Set(json.result);
@@ -113,11 +116,11 @@ function ResourceDetail(props) {
       }
     }
     didMount();
-  }, [props.authed, props.match.params.id, updateIsSaved]);
+  }, [authed, props.match.params.id, updateIsSaved]);
 
   useEffect(() => {
     async function didUpdate() {
-      if (props.authed) {
+      if (authed) {
         let savedSet = new Set();
         const json = await getSavedResources();
         savedSet = new Set(json.result);
@@ -125,7 +128,7 @@ function ResourceDetail(props) {
       }
     }
     didUpdate();
-  }, [props.authed, updateIsSaved]);
+  }, [authed, updateIsSaved]);
 
   useEffect(() => {
     let adr = 'No address provided.';
@@ -219,7 +222,7 @@ function ResourceDetail(props) {
     interactive: true,
   });
 
-  const { authed, match, authRoleIsEquivalentTo } = props;
+  const { match } = props;
 
   if (!resourceExists) {
     return <Redirect to="/resources/unknown" />;
@@ -249,7 +252,6 @@ function ResourceDetail(props) {
         <Col span={15}>
           <span className="resource-name">{`${name}\n`}</span>
           <SaveButton
-            authed={authed}
             isSaved={isSaved}
             deleteResourceHandler={deleteSavedResourceHandler}
             saveResourceHandler={saveResourceHandler}
@@ -507,8 +509,6 @@ ResourceDetail.defaultProps = {
 };
 
 ResourceDetail.propTypes = {
-  authed: PropTypes.bool.isRequired,
-  authRoleIsEquivalentTo: PropTypes.func.isRequired,
   history: PropTypes.element,
   match: PropTypes.shape({
     params: PropTypes.shape({ id: PropTypes.string }),

--- a/client/src/components/mobile/NavigationMobile.js
+++ b/client/src/components/mobile/NavigationMobile.js
@@ -6,13 +6,10 @@ import { MenuOutlined } from '@ant-design/icons';
 import { Drawer, Button, Menu } from 'antd';
 import '../../css_mobile/Navigation.css';
 
-type Props = {
-  authed: Boolean,
-  authRoleIsEquivalentTo: String => Boolean,
-};
+import { useAuth } from '../../utils/use-auth';
 
-const NavMobile = (props: Props) => {
-  const { authed, authRoleIsEquivalentTo } = props;
+const NavMobile = () => {
+  const { authed, authRoleIsEquivalentTo } = useAuth();
   const [drawerVisible, setDrawerVisible] = useState(false);
 
   return (

--- a/client/src/components/mobile/ResourceDetailMobile.js
+++ b/client/src/components/mobile/ResourceDetailMobile.js
@@ -288,7 +288,6 @@ const ResourceDetailMobile = (props: Props) => {
             </Col>
             <Col>
               <SaveButton
-                authed={authed}
                 isSaved={isSaved}
                 deleteResourceHandler={deleteResourceHandler}
                 saveResourceHandler={saveResourceHandler}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -4,11 +4,11 @@ import { Col, Row } from 'antd';
 
 import { getHomePage } from '../utils/api';
 import getIsWebpSupported from '../utils/webp-detect';
+import useWindowDimensions from '../utils/mobile';
 
 import '../css/Home.css';
 import '../css_mobile/Home.css';
 
-import useWindowDimensions from '../utils/mobile';
 import {
   HomeBlock1Desktop,
   HomeBlock2Desktop,

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -9,7 +9,6 @@ import { Button, Checkbox, Input, Row, Col } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
-import { login } from '../utils/auth';
 import { useAuth } from '../utils/use-auth';
 
 type Props = {
@@ -17,7 +16,7 @@ type Props = {
 };
 
 function Login(props: Props) {
-  const { setAuthed, setAuthRole } = useAuth();
+  const { login } = useAuth();
   const { form } = props;
   const { getFieldDecorator } = form;
   const [error, setError] = useState('');
@@ -29,21 +28,17 @@ function Login(props: Props) {
       form.validateFields((err, values) => {
         if (!err) {
           const { email, password } = values;
-          login({ email, password }).then(res => {
-            if (res.status === 200) {
-              localStorage.setItem('token', res.token);
-
-              setAuthed(true);
-              setAuthRole(res.permission);
-              setError('');
+          login({ email, password }).then(errorMessage => {
+            if (errorMessage !== null) {
+              setError(errorMessage);
             } else {
-              setError(res.message);
+              setError(null);
             }
           });
         }
       });
     },
-    [form, setAuthed, setAuthRole],
+    [form, login],
   );
 
   return (

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -10,15 +10,15 @@ import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
 import { login } from '../utils/auth';
+import { useAuth } from '../utils/use-auth';
 
 type Props = {
   form: Form,
-  setAuthed: boolean => void,
-  setAuthRole: Boolean => void,
 };
 
 function Login(props: Props) {
-  const { form, setAuthed, setAuthRole } = props;
+  const { setAuthed, setAuthRole } = useAuth();
+  const { form } = props;
   const { getFieldDecorator } = form;
   const [error, setError] = useState('');
 

--- a/client/src/pages/Logout.js
+++ b/client/src/pages/Logout.js
@@ -6,12 +6,8 @@ import { Redirect } from 'react-router-dom';
 import { useAuth } from '../utils/use-auth';
 
 const Logout = () => {
-  const { setAuthed, setAuthRole } = useAuth();
-
-  localStorage.removeItem('token');
-  setAuthed(false);
-  setAuthRole('');
-
+  const { logout } = useAuth();
+  logout();
   return <Redirect to="/" />;
 };
 

--- a/client/src/pages/Logout.js
+++ b/client/src/pages/Logout.js
@@ -3,12 +3,10 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 
-type Props = {
-  setAuthRole: String => void,
-  setAuthed: boolean => void,
-};
-const Logout = (props: Props) => {
-  const { setAuthed, setAuthRole } = props;
+import { useAuth } from '../utils/use-auth';
+
+const Logout = () => {
+  const { setAuthed, setAuthRole } = useAuth();
 
   localStorage.removeItem('token');
   setAuthed(false);

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+// @flow
+
+import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
@@ -7,23 +9,13 @@ import { Button, Input, Select, Row, Col, message } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
-import { getSecurityQuestions, resetPassword } from '../utils/auth';
 import { useAuth } from '../utils/use-auth';
 
 const { Option } = Select;
 
 const PasswordReset = ({ form }) => {
-  const { setAuthed, setAuthRole } = useAuth();
+  const { resetPassword, securityQuestions } = useAuth();
   const [confirmDirty, setConfirmDirty] = useState(true);
-  const [securityQuestions, setSecurityQuestions] = useState([]);
-
-  useEffect(() => {
-    async function fetchSecurityQuestions() {
-      const securityQuestionsData = await getSecurityQuestions();
-      setSecurityQuestions(securityQuestionsData.questions);
-    }
-    fetchSecurityQuestions();
-  }, [setSecurityQuestions]);
 
   const handleConfirmBlur = useCallback(
     e => {
@@ -55,20 +47,15 @@ const PasswordReset = ({ form }) => {
       form.validateFields((err, values) => {
         if (!err) {
           const { email, password, answer } = values;
-          resetPassword({ email, password, answer }).then(res => {
-            if (res.status === 200) {
-              localStorage.setItem('token', res.token);
-              setAuthed(true);
-              setAuthRole(res.permission);
-            } else {
-              // show error message
-              message.error(res.message);
+          resetPassword({ email, password, answer }).then(errorMessage => {
+            if (errorMessage !== null) {
+              message.error(errorMessage);
             }
           });
         }
       });
     },
-    [form, setAuthed, setAuthRole],
+    [form, resetPassword],
   );
 
   const { getFieldDecorator } = form;

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { PropTypes } from 'prop-types';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
 import '@ant-design/compatible/assets/index.css';
@@ -9,10 +8,12 @@ import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
 import { getSecurityQuestions, resetPassword } from '../utils/auth';
+import { useAuth } from '../utils/use-auth';
 
 const { Option } = Select;
 
-const PasswordReset = ({ form, setAuthed, setAuthRole }) => {
+const PasswordReset = ({ form }) => {
+  const { setAuthed, setAuthRole } = useAuth();
   const [confirmDirty, setConfirmDirty] = useState(true);
   const [securityQuestions, setSecurityQuestions] = useState([]);
 
@@ -179,8 +180,6 @@ const PasswordReset = ({ form, setAuthed, setAuthRole }) => {
 
 PasswordReset.propTypes = {
   form: Form.isRequired,
-  setAuthed: PropTypes.func.isRequired,
-  setAuthRole: PropTypes.func.isRequired,
 };
 
 export default Form.create()(PasswordReset);

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+// @flow
+
+import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
@@ -7,23 +9,13 @@ import { Button, Input, Select, Row, Col, message } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
-import { getSecurityQuestions, register } from '../utils/auth';
 import { useAuth } from '../utils/use-auth';
 
 const { Option } = Select;
 
 const Register = ({ form }) => {
-  const { setAuthed, setAuthRole } = useAuth();
+  const { register, securityQuestions } = useAuth();
   const [confirmDirty, setConfirmDirty] = useState(true);
-  const [securityQuestions, setSecurityQuestions] = useState([]);
-
-  useEffect(() => {
-    async function fetchSecurityQuestions() {
-      const securityQuestionsData = await getSecurityQuestions();
-      setSecurityQuestions(securityQuestionsData.questions);
-    }
-    fetchSecurityQuestions();
-  }, [setSecurityQuestions]);
 
   const handleConfirmBlur = useCallback(
     e => {
@@ -55,20 +47,17 @@ const Register = ({ form }) => {
       form.validateFields((err, values) => {
         if (!err) {
           const { email, password, questionIdx, answer } = values;
-          register({ email, password, questionIdx, answer }).then(res => {
-            if (res.status === 200) {
-              localStorage.setItem('token', res.token);
-              setAuthed(true);
-              setAuthRole(res.permission);
-            } else {
-              // show error message
-              message.error(res.message);
-            }
-          });
+          register({ email, password, questionIdx, answer }).then(
+            errorMessage => {
+              if (errorMessage !== null) {
+                message.error(errorMessage);
+              }
+            },
+          );
         }
       });
     },
-    [form, setAuthed, setAuthRole],
+    [form, register],
   );
 
   const { getFieldDecorator } = form;

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { PropTypes } from 'prop-types';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
 import '@ant-design/compatible/assets/index.css';
@@ -9,10 +8,12 @@ import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
 import { getSecurityQuestions, register } from '../utils/auth';
+import { useAuth } from '../utils/use-auth';
 
 const { Option } = Select;
 
-const Register = ({ form, setAuthed, setAuthRole }) => {
+const Register = ({ form }) => {
+  const { setAuthed, setAuthRole } = useAuth();
   const [confirmDirty, setConfirmDirty] = useState(true);
   const [securityQuestions, setSecurityQuestions] = useState([]);
 
@@ -179,8 +180,6 @@ const Register = ({ form, setAuthed, setAuthRole }) => {
 
 Register.propTypes = {
   form: Form.isRequired,
-  setAuthed: PropTypes.func.isRequired,
-  setAuthRole: PropTypes.func.isRequired,
 };
 
 export default Form.create()(Register);

--- a/client/src/pages/Resources.js
+++ b/client/src/pages/Resources.js
@@ -13,6 +13,7 @@ import { getSavedResources } from '../utils/auth';
 import languages from '../data/languages';
 import locations from '../data/locations';
 import useWindowDimensions from '../utils/mobile';
+import { useAuth } from '../utils/use-auth';
 import ResourcesBanner from '../components/desktop/ResourcesBanner';
 import ResourcesFilter from '../components/desktop/ResourcesFilter';
 import ResourcesGrid from '../components/ResourcesGrid';
@@ -40,6 +41,7 @@ function Resources(props) {
   const costs = ['Free', 'Free - $', 'Free - $$', 'Free - $$$'];
   const sorts = ['Name', 'Cost'];
   const isMobile = useWindowDimensions()[1];
+  const { authed } = useAuth();
 
   const fetchCategories = async () => {
     const res = await getCategories();
@@ -112,7 +114,7 @@ function Resources(props) {
         : await getResourcesByCategory(categorySelected);
 
     let localSavedSet = new Set();
-    if (props.authed) {
+    if (authed) {
       const json = await getSavedResources();
       localSavedSet = new Set(json.result);
       setSavedSet(localSavedSet);
@@ -137,7 +139,7 @@ function Resources(props) {
     setSubcategory(subcategorySelected);
 
     setLoading(false);
-  }, [getCategorySelectedFromSearch, props.saved, props.authed]);
+  }, [getCategorySelectedFromSearch, props.saved, authed]);
 
   const updateSaved = async () => {
     updateResources();
@@ -161,7 +163,7 @@ function Resources(props) {
 
   useEffect(() => {
     updateResources();
-  }, [props.location.search, props.saved, props.authed, updateResources]);
+  }, [props.location.search, props.saved, authed, updateResources]);
 
   useEffect(() => {
     const costMap = {
@@ -315,7 +317,6 @@ function Resources(props) {
           <ResourcesGrid
             filteredResources={filteredResources}
             savedResources={savedSet}
-            authed={props.authed}
             updateSaved={updateSaved}
           />
         )}
@@ -328,7 +329,6 @@ Resources.defaultProps = {
   location: { search: '' },
   history: { pathname: '', search: '' },
   saved: false,
-  authed: false,
 };
 
 Resources.propTypes = {
@@ -339,7 +339,6 @@ Resources.propTypes = {
     search: PropTypes.string,
   }),
   saved: PropTypes.bool,
-  authed: PropTypes.bool,
 };
 
 export default Resources;

--- a/client/src/pages/SavedResources.js
+++ b/client/src/pages/SavedResources.js
@@ -11,6 +11,7 @@ import useWindowDimensions from '../utils/mobile';
 import ResourcesBanner from '../components/desktop/ResourcesBanner';
 import ResourcesGrid from '../components/ResourcesGrid';
 import ResourcesBannerMobile from '../components/mobile/ResourcesBannerMobile';
+import { useAuth } from '../utils/use-auth';
 
 function SavedResources(props) {
   const [loading, setLoading] = useState(false);
@@ -19,7 +20,7 @@ function SavedResources(props) {
   const [savedSet, setSavedSet] = useState(new Set());
 
   const isMobile = useWindowDimensions()[1];
-  const { authed } = props;
+  const { authed } = useAuth();
 
   const updateSaved = useCallback(async () => {
     setLoading(true);
@@ -81,7 +82,6 @@ function SavedResources(props) {
           <ResourcesGrid
             filteredResources={resources}
             savedResources={savedSet}
-            authed={authed}
             updateSaved={updateSaved}
           />
         )}
@@ -93,7 +93,6 @@ function SavedResources(props) {
 SavedResources.defaultProps = {
   location: { search: '' },
   history: { pathname: '', search: '' },
-  authed: false,
 };
 
 SavedResources.propTypes = {
@@ -103,7 +102,6 @@ SavedResources.propTypes = {
     push: PropTypes.func,
     search: PropTypes.string,
   }),
-  authed: PropTypes.bool,
 };
 
 export default SavedResources;


### PR DESCRIPTION
This PR stack will ultimately clean up and centralize all of the auth code so that it's more easily understandable. This will be done using providers and contexts so that we don't have to pass the auth props down multiple component levels.

This PR specifically eliminates passing down any auth props, and instead replaces it with `useAuth`.

I tested all of the views (since I touched all of them with these changes) to ensure they still worked.
