### PR TITLE
🧹 Clean up auth code [PART 3]

### DIFF
--- a/auth/package.json
+++ b/auth/package.json
@@ -32,7 +32,7 @@
     "node-fetch": "^2.3.0",
     "node-pre-gyp": "^0.12.0",
     "nodemailer": "^5.1.1",
-    "nodemon": "^1.19.4",
+    "nodemon": "^1.18.10",
     "prettier": "^1.17.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/auth/package.json
+++ b/auth/package.json
@@ -32,7 +32,7 @@
     "node-fetch": "^2.3.0",
     "node-pre-gyp": "^0.12.0",
     "nodemailer": "^5.1.1",
-    "nodemon": "^1.18.10",
+    "nodemon": "^1.19.4",
     "prettier": "^1.17.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/client/src/components/mobile/ResourceDetailMobile.js
+++ b/client/src/components/mobile/ResourceDetailMobile.js
@@ -288,7 +288,6 @@ const ResourceDetailMobile = (props: Props) => {
             </Col>
             <Col>
               <SaveButton
-                authed={authed}
                 isSaved={isSaved}
                 deleteResourceHandler={deleteResourceHandler}
                 saveResourceHandler={saveResourceHandler}

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -9,7 +9,6 @@ import { Button, Checkbox, Input, Row, Col } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
-import { login } from '../utils/auth';
 import { useAuth } from '../utils/use-auth';
 
 type Props = {
@@ -17,7 +16,7 @@ type Props = {
 };
 
 function Login(props: Props) {
-  const { setAuthed, setAuthRole } = useAuth();
+  const { login } = useAuth();
   const { form } = props;
   const { getFieldDecorator } = form;
   const [error, setError] = useState('');
@@ -29,21 +28,17 @@ function Login(props: Props) {
       form.validateFields((err, values) => {
         if (!err) {
           const { email, password } = values;
-          login({ email, password }).then(res => {
-            if (res.status === 200) {
-              localStorage.setItem('token', res.token);
-
-              setAuthed(true);
-              setAuthRole(res.permission);
-              setError('');
+          login({ email, password }).then(errorMessage => {
+            if (errorMessage !== null) {
+              setError(errorMessage);
             } else {
-              setError(res.message);
+              setError('');
             }
           });
         }
       });
     },
-    [form, setAuthed, setAuthRole],
+    [form],
   );
 
   return (

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -32,7 +32,7 @@ function Login(props: Props) {
             if (errorMessage !== null) {
               setError(errorMessage);
             } else {
-              setError('');
+              setError(null);
             }
           });
         }

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -38,7 +38,7 @@ function Login(props: Props) {
         }
       });
     },
-    [form],
+    [form, login],
   );
 
   return (

--- a/client/src/pages/Logout.js
+++ b/client/src/pages/Logout.js
@@ -6,12 +6,8 @@ import { Redirect } from 'react-router-dom';
 import { useAuth } from '../utils/use-auth';
 
 const Logout = () => {
-  const { setAuthed, setAuthRole } = useAuth();
-
-  localStorage.removeItem('token');
-  setAuthed(false);
-  setAuthRole('');
-
+  const { logout } = useAuth();
+  logout();
   return <Redirect to="/" />;
 };
 

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -55,7 +55,7 @@ const PasswordReset = ({ form }) => {
         }
       });
     },
-    [form],
+    [form, resetPassword],
   );
 
   const { getFieldDecorator } = form;

--- a/client/src/pages/PasswordReset.js
+++ b/client/src/pages/PasswordReset.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+// @flow
+
+import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
@@ -7,23 +9,13 @@ import { Button, Input, Select, Row, Col, message } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
-import { getSecurityQuestions, resetPassword } from '../utils/auth';
 import { useAuth } from '../utils/use-auth';
 
 const { Option } = Select;
 
 const PasswordReset = ({ form }) => {
-  const { setAuthed, setAuthRole } = useAuth();
+  const { resetPassword, securityQuestions } = useAuth();
   const [confirmDirty, setConfirmDirty] = useState(true);
-  const [securityQuestions, setSecurityQuestions] = useState([]);
-
-  useEffect(() => {
-    async function fetchSecurityQuestions() {
-      const securityQuestionsData = await getSecurityQuestions();
-      setSecurityQuestions(securityQuestionsData.questions);
-    }
-    fetchSecurityQuestions();
-  }, [setSecurityQuestions]);
 
   const handleConfirmBlur = useCallback(
     e => {
@@ -55,20 +47,15 @@ const PasswordReset = ({ form }) => {
       form.validateFields((err, values) => {
         if (!err) {
           const { email, password, answer } = values;
-          resetPassword({ email, password, answer }).then(res => {
-            if (res.status === 200) {
-              localStorage.setItem('token', res.token);
-              setAuthed(true);
-              setAuthRole(res.permission);
-            } else {
-              // show error message
-              message.error(res.message);
+          resetPassword({ email, password, answer }).then(errorMessage => {
+            if (errorMessage !== null) {
+              message.error(errorMessage);
             }
           });
         }
       });
     },
-    [form, setAuthed, setAuthRole],
+    [form],
   );
 
   const { getFieldDecorator } = form;

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -57,7 +57,7 @@ const Register = ({ form }) => {
         }
       });
     },
-    [form],
+    [form, register],
   );
 
   const { getFieldDecorator } = form;

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+// @flow
+
+import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
@@ -7,23 +9,13 @@ import { Button, Input, Select, Row, Col, message } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
-import { getSecurityQuestions, register } from '../utils/auth';
 import { useAuth } from '../utils/use-auth';
 
 const { Option } = Select;
 
 const Register = ({ form }) => {
-  const { setAuthed, setAuthRole } = useAuth();
+  const { register, securityQuestions } = useAuth();
   const [confirmDirty, setConfirmDirty] = useState(true);
-  const [securityQuestions, setSecurityQuestions] = useState([]);
-
-  useEffect(() => {
-    async function fetchSecurityQuestions() {
-      const securityQuestionsData = await getSecurityQuestions();
-      setSecurityQuestions(securityQuestionsData.questions);
-    }
-    fetchSecurityQuestions();
-  }, [setSecurityQuestions]);
 
   const handleConfirmBlur = useCallback(
     e => {
@@ -55,20 +47,17 @@ const Register = ({ form }) => {
       form.validateFields((err, values) => {
         if (!err) {
           const { email, password, questionIdx, answer } = values;
-          register({ email, password, questionIdx, answer }).then(res => {
-            if (res.status === 200) {
-              localStorage.setItem('token', res.token);
-              setAuthed(true);
-              setAuthRole(res.permission);
-            } else {
-              // show error message
-              message.error(res.message);
-            }
-          });
+          register({ email, password, questionIdx, answer }).then(
+            errorMessage => {
+              if (errorMessage !== null) {
+                message.error(errorMessage);
+              }
+            },
+          );
         }
       });
     },
-    [form, setAuthed, setAuthRole],
+    [form],
   );
 
   const { getFieldDecorator } = form;

--- a/client/src/utils/use-auth.js
+++ b/client/src/utils/use-auth.js
@@ -10,7 +10,14 @@ import {
   createContext,
 } from 'react';
 
-import { verify, getAllRoles } from './auth';
+import {
+  login as loginHelper,
+  getSecurityQuestions,
+  register as registerHelper,
+  resetPassword as resetPasswordHelper,
+  verify,
+  getAllRoles,
+} from './auth';
 
 type ProvideAuthParams = {
   children: React.Node,
@@ -19,8 +26,20 @@ type ProvideAuthParams = {
 type Auth = {
   authed: ?boolean,
   authRoleIsEquivalentTo: string => ?boolean,
-  setAuthed: (?boolean) => void,
-  setAuthRole: (?string) => void,
+  login: ({ email: string, password: string }) => Promise<?string>,
+  logout: () => void,
+  register: ({
+    email: string,
+    password: string,
+    questionIdx: string,
+    answer: string,
+  }) => Promise<?string>,
+  resetPassword: ({
+    email: string,
+    password: string,
+    answer: string,
+  }) => Promise<?string>,
+  securityQuestions: Array<string>,
 };
 
 // Provider hook that creates auth object and handles state
@@ -28,10 +47,12 @@ function useProvideAuth(): Auth {
   const [authed, setAuthed] = useState<?boolean>(null);
   const [authRole, setAuthRole] = useState<?string>(null);
   const [authRoles, setAuthRoles] = useState<?Array<string>>(null);
+  const [securityQuestions, setSecurityQuestions] = useState<Array<string>>([]);
 
   useEffect(() => {
     async function fetchData() {
       Promise.all([
+        getSecurityQuestions(),
         getAllRoles(),
         verify(
           res => {
@@ -43,7 +64,10 @@ function useProvideAuth(): Auth {
             setAuthRole('');
           },
         ),
-      ]).then(vals => setAuthRoles(Object.keys(vals[0].roles).concat('')));
+      ]).then(vals => {
+        setSecurityQuestions(vals[0].questions);
+        setAuthRoles(Object.keys(vals[1].roles).concat(''));
+      });
     }
     fetchData();
   }, []);
@@ -64,19 +88,56 @@ function useProvideAuth(): Auth {
     [authRole, authRoles],
   );
 
+  const authUser = res => {
+    if (res.status === 200) {
+      localStorage.setItem('token', res.token);
+      setAuthed(true);
+      setAuthRole(res.permission);
+      return null;
+    }
+    return res.message;
+  };
+
+  const register = async params => {
+    const res = await registerHelper(params);
+    return authUser(res);
+  };
+
+  const resetPassword = async params => {
+    const res = await resetPasswordHelper(params);
+    return authUser(res);
+  };
+
+  const login = async params => {
+    const res = await loginHelper(params);
+    return authUser(res);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setAuthed(false);
+    setAuthRole('');
+  };
+
   return {
     authed,
     authRoleIsEquivalentTo,
-    setAuthed,
-    setAuthRole,
+    login,
+    logout,
+    register,
+    resetPassword,
+    securityQuestions,
   };
 }
 
 const defaultContext: Auth = {
   authed: null,
   authRoleIsEquivalentTo: () => null,
-  setAuthed: () => {},
-  setAuthRole: () => {},
+  login: () => new Promise(() => {}),
+  logout: () => {},
+  register: () => new Promise(() => {}),
+  resetPassword: () => new Promise(() => {}),
+  securityQuestions: [],
 };
 
 const authContext = createContext<Auth>(defaultContext);


### PR DESCRIPTION
This PR stack will ultimately clean up and centralize all of the auth code so that it's more easily understandable. This will be done using providers and contexts so that we don't have to pass the auth props down multiple component levels.  This is the last PR in the stack.

This PR specifically tries to consolidate some of the auth code, and centralize it within the hook.  So, rather than the component itself setting whether a user is authed, or setting their auth role, all they have to do is call the register/login/etc. function returned from the hook.  More of the auth logic is abstracted away as a result of this.

I tested all of the views (since I touched all of them with these changes) to ensure they still worked.