### PR TITLE
✍️ Set retry writes to false

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -20,6 +20,7 @@ if (process.env.NODE_ENV != 'production') {
 }
 
 mongoose.connect(process.env.MONGO_URL, {
+  retryWrites: false,
   useNewUrlParser: true,
   useUnifiedTopology: true,
 });


### PR DESCRIPTION
There was an error with mlab not accepting any writes as a result of us implicitly having [retryWrites set to true](https://docs.mlab.com/faq/#:~:text=investigate%20possible%20causes.-,Why%20am%20I%20getting%20the%20%E2%80%9CTransaction%20numbers%20are%20only%20allowed,on%20the%20MMAPv1%20storage%20engine.).  This PR sets it to false, and I also created an issue to reset it to true #289 once we move to Atlas.
