### PR TITLE
🐲 Fix category carousel not appearing

### DIFF
--- a/client/src/components/desktop/HomeDesktop.jsx
+++ b/client/src/components/desktop/HomeDesktop.jsx
@@ -92,7 +92,7 @@ export const HomeBlock1Desktop = () => {
               >
                 {categories.map(
                   (category) =>
-                    !category === 'Other' && (
+                    category !== 'Other' && (
                       <Link
                         to={`/resources?category=${category}`}
                         className="welcome-text-link"


### PR DESCRIPTION
The category carousel on the homepage wasn't appearing due to an error that occurred after fixing some linting issues.  This PR fixes that
