### PR TITLE
🍜 Reformat now to vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,5 @@
 {
-  "version": 2,
-  "name": "nawc",
-  "alias": "nawc.now.sh",
+  "regions": ["iad1"],
   "env": {
     "MONGO_URL": "@ymca_db_uri",
     "MAPBOX_KEY": "@ymca_mapbox_key",

--- a/vercel.json
+++ b/vercel.json
@@ -13,16 +13,16 @@
   "builds": [
     {
       "src": "api/src/app.js",
-      "use": "@now/node"
+      "use": "@vercel/node"
     },
     {
       "src": "client/package.json",
-      "use": "@now/static-build",
+      "use": "@vercel/static-build",
       "config": {
         "distDir": "build"
       }
     },
-    { "src": "auth/src/nowServer.js", "use": "@now/node" }
+    { "src": "auth/src/nowServer.js", "use": "@vercel/node" }
   ],
   "routes": [
     { "src": "/auth/(.*)", "dest": "auth/src/nowServer.js" },


### PR DESCRIPTION
Stops using now.json, now uses vercel.json
