### PR TITLE
🧛 Force absolute URL for resource website

### DIFF
--- a/client/src/components/desktop/ResourceDetail.jsx
+++ b/client/src/components/desktop/ResourceDetail.jsx
@@ -229,6 +229,11 @@ function ResourceDetail(props) {
     return <Redirect to="/resources/unknown" />;
   }
 
+  let absoluteWebsiteURL = website;
+  if (website.includes('http') === false) {
+    absoluteWebsiteURL = `//${website}`;
+  }
+
   return (
     <div className="resource-detail">
       <Modal
@@ -280,7 +285,11 @@ function ResourceDetail(props) {
         </Col>
         <Col span={8} className="header-info">
           {website.length > 0 ? (
-            <a href={website} target="_blank" rel="noopener noreferrer">
+            <a
+              href={absoluteWebsiteURL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {`${website}`}
               {'\n'}
             </a>


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:


:rocket: Ready
<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->
Originally, we weren't forcing an "absolute url" to another resource's website - this PR fixes that.

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
![image](https://user-images.githubusercontent.com/32113753/108001620-8586d500-6fb2-11eb-976e-5a24e8084d72.png)
