### PR TITLE
🐞 Resolve various bugs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,7 +56,7 @@
     "@babel/cli": "^7.6.2",
     "@babel/core": "^7.6.2",
     "@babel/preset-flow": "^7.0.0",
-    "@hack4impact-uiuc/eslint-plugin": "^2.0.9",
+    "@hack4impact-uiuc/eslint-plugin": "^2.0.10",
     "cypress": "^6.1.0",
     "eslint": "^7.18.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -74,21 +74,6 @@ const App = (): React$Element<React$FragmentType> => {
         >
           <Switch>
             <Route path="/" exact component={Home} />
-            {/* <Route
-              path="/"
-              render={() => (
-                <Loader
-                  className="app-loader"
-                  type="Circles"
-                  color="#6A3E9E"
-                  height={100}
-                  width={100}
-                  style={{
-                    textAlign: 'center',
-                  }}
-                />
-              )}
-            /> */}
             <PrivateRoute
               path="/admin"
               component={AdminResourceManager}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import {
   Switch,
   Redirect,
 } from 'react-router-dom';
+import Loader from 'react-loader-spinner';
 import PrivateRoute from './components/PrivateRoute';
 import Footer from './components/Footer';
 import Navigation from './components/Navigation';
@@ -57,9 +58,37 @@ const App = (): React$Element<React$FragmentType> => {
       <Router>
         <ScrollToTop />
         <Navigation />
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense
+          fallback={
+            <Loader
+              className="app-loader"
+              type="Circles"
+              color="#6A3E9E"
+              height={100}
+              width={100}
+              style={{
+                textAlign: 'center',
+              }}
+            />
+          }
+        >
           <Switch>
             <Route path="/" exact component={Home} />
+            {/* <Route
+              path="/"
+              render={() => (
+                <Loader
+                  className="app-loader"
+                  type="Circles"
+                  color="#6A3E9E"
+                  height={100}
+                  width={100}
+                  style={{
+                    textAlign: 'center',
+                  }}
+                />
+              )}
+            /> */}
             <PrivateRoute
               path="/admin"
               component={AdminResourceManager}

--- a/client/src/components/ResourceContactForm.jsx
+++ b/client/src/components/ResourceContactForm.jsx
@@ -29,40 +29,39 @@ const ContactForm = Form.create({ name: 'contactForm' })((props) => {
 
   const { getFieldDecorator, setFieldsValue, getFieldValue } = props.form;
 
+  const onSubmit = () => {
+    const contactName = getFieldValue('contactName');
+    const contactRole = getFieldValue('contactRole');
+
+    if (
+      contactName !== undefined &&
+      contactRole !== undefined &&
+      contactName.trim() !== '' &&
+      contactRole.trim() !== ''
+    ) {
+      setContacts([
+        ...contacts,
+        {
+          name: contactName,
+          role: contactRole,
+          email: getFieldValue('contactEmail') || '',
+          phoneNumber: getFieldValue('contactPhoneNumber') || '',
+          note: getFieldValue('contactNote') || '',
+        },
+      ]);
+
+      setFieldsValue({
+        contactName: '',
+        contactRole: '',
+        contactEmail: '',
+        contactPhoneNumber: '',
+        contactNote: '',
+      });
+    }
+  };
+
   return (
-    <Form
-      className="contact-form"
-      onSubmit={() => {
-        const contactName = getFieldValue('contactName');
-        const contactRole = getFieldValue('contactRole');
-
-        if (
-          contactName !== undefined &&
-          contactRole !== undefined &&
-          contactName.trim() !== '' &&
-          contactRole.trim() !== ''
-        ) {
-          setContacts([
-            ...contacts,
-            {
-              name: contactName,
-              role: contactRole,
-              email: getFieldValue('contactEmail') || '',
-              phoneNumber: getFieldValue('contactPhoneNumber') || '',
-              note: getFieldValue('contactNote') || '',
-            },
-          ]);
-
-          setFieldsValue({
-            contactName: '',
-            contactRole: '',
-            contactEmail: '',
-            contactPhoneNumber: '',
-            contactNote: '',
-          });
-        }
-      }}
-    >
+    <Form className="contact-form">
       <Form.Item>
         {getFieldDecorator('contactName', {
           rules: [
@@ -144,9 +143,11 @@ const ContactForm = Form.create({ name: 'contactForm' })((props) => {
       </Form.Item>
       <Button
         type="primary"
-        htmlType="submit"
         className="contact-submit form-btn"
-        onClick={() => setTotalSubmitEnabled(false)}
+        onClick={() => {
+          setTotalSubmitEnabled(false);
+          onSubmit();
+        }}
       >
         Add Contact
       </Button>

--- a/client/src/components/ResourceFinancialAidForm.jsx
+++ b/client/src/components/ResourceFinancialAidForm.jsx
@@ -1,9 +1,5 @@
 // @flow
 
-/*
-TODO: Implement phoneType into form.
-*/
-
 import React from 'react';
 import '../css/ResourcePhoneNumberForm.css';
 import { Form } from '@ant-design/compatible';
@@ -15,18 +11,17 @@ const FinancialAidForm = Form.create({ name: 'financialAid' })((props) => {
 
   const { getFieldDecorator, getFieldValue } = props.form;
 
+  const onSubmit = () => {
+    setFinancialAidDetails({
+      education: getFieldValue('education'),
+      immigrationStatus: getFieldValue('immigrationStatus'),
+      deadline: getFieldValue('deadline'),
+      amount: getFieldValue('amount'),
+    });
+  };
+
   return (
-    <Form
-      className="financial-aid-form"
-      onSubmit={() => {
-        setFinancialAidDetails({
-          education: getFieldValue('education'),
-          immigrationStatus: getFieldValue('immigrationStatus'),
-          deadline: getFieldValue('deadline'),
-          amount: getFieldValue('amount'),
-        });
-      }}
-    >
+    <Form className="financial-aid-form">
       <Form.Item>
         {getFieldDecorator(
           'education',
@@ -81,9 +76,11 @@ const FinancialAidForm = Form.create({ name: 'financialAid' })((props) => {
       </Form.Item>
       <Button
         type="primary"
-        htmlType="submit"
         className="financial-aid-form form-btn"
-        onClick={() => setTotalSubmitEnabled(false)}
+        onClick={() => {
+          setTotalSubmitEnabled(false);
+          onSubmit();
+        }}
       >
         Add Financial Aid Details
       </Button>

--- a/client/src/components/ResourceHoursOfOperationForm.jsx
+++ b/client/src/components/ResourceHoursOfOperationForm.jsx
@@ -135,7 +135,6 @@ const HoursOfOperationsForm = Form.create({ name: 'hoursOfOperation' })(
         <Button
           type="primary"
           className="form-btn"
-          htmlType="submit"
           onClick={() => {
             setTotalSubmitEnabled(false);
             updateHoursOfOperation({

--- a/client/src/components/ResourceInternalNotesForm.jsx
+++ b/client/src/components/ResourceInternalNotesForm.jsx
@@ -35,8 +35,7 @@ const InternalNotesForm = Form.create({ name: 'internalNotes' })(
     } = props;
     const { getFieldDecorator, getFieldValue, setFieldsValue } = props.form;
 
-    const onSubmit = (e) => {
-      e.preventDefault();
+    const onSubmit = () => {
       const subject = getFieldValue('subject');
       const body = getFieldValue('body');
       const note = { subject, body };
@@ -72,7 +71,7 @@ const InternalNotesForm = Form.create({ name: 'internalNotes' })(
     }, [editNote, setFieldsValue]);
 
     return (
-      <Form onSubmit={onSubmit}>
+      <Form>
         <Form.Item>
           {getFieldDecorator('subject', {
             rules: [
@@ -85,7 +84,8 @@ const InternalNotesForm = Form.create({ name: 'internalNotes' })(
           })(
             <Input
               placeholder="Subject"
-              defaultValue={!editNote == null && editNote.body}
+              // eslint-disable-next-line @hack4impact-uiuc/no-null-ternary
+              defaultValue={!editNote == null ? editNote.body : null}
             />,
           )}
         </Form.Item>
@@ -114,9 +114,11 @@ const InternalNotesForm = Form.create({ name: 'internalNotes' })(
 
         <Button
           type="primary"
-          htmlType="submit"
           className="form-btn"
-          onClick={() => setTotalSubmitEnabled(false)}
+          onClick={() => {
+            setTotalSubmitEnabled(false);
+            onSubmit();
+          }}
         >
           {editNote == null ? 'Add Note' : 'Edit Note'}
         </Button>

--- a/client/src/components/ResourceInternalNotesForm.jsx
+++ b/client/src/components/ResourceInternalNotesForm.jsx
@@ -81,13 +81,7 @@ const InternalNotesForm = Form.create({ name: 'internalNotes' })(
                 whitespace: true,
               },
             ],
-          })(
-            <Input
-              placeholder="Subject"
-              // eslint-disable-next-line @hack4impact-uiuc/no-null-ternary
-              defaultValue={!editNote == null ? editNote.body : null}
-            />,
-          )}
+          })(<Input placeholder="Subject" defaultValue={editNote?.subject} />)}
         </Form.Item>
         <Form.Item>
           {getFieldDecorator('body', {
@@ -107,7 +101,7 @@ const InternalNotesForm = Form.create({ name: 'internalNotes' })(
                 If letter from immigration authority in chicago most 
                 likely deportation proceedings. 
                 No one really in the area does this."
-              defaultValue={!editNote == null && editNote.body}
+              defaultValue={editNote?.body}
             />,
           )}
         </Form.Item>

--- a/client/src/components/ResourcePhoneNumberForm.jsx
+++ b/client/src/components/ResourcePhoneNumberForm.jsx
@@ -14,29 +14,28 @@ const PhoneNumberForm = Form.create({ name: 'phoneNumber' })((props) => {
   const { setPhoneNumbers, phoneNumbers, setTotalSubmitEnabled } = props;
   const { setFieldsValue, getFieldValue, getFieldDecorator } = props.form;
 
+  const onSubmit = () => {
+    const phoneNumber = getFieldValue('phoneNumber');
+    const phoneType = getFieldValue('phoneType') || '';
+
+    if (phoneNumber !== undefined && phoneNumber.trim() !== '') {
+      setPhoneNumbers([
+        ...phoneNumbers,
+        {
+          phoneNumber,
+          phoneType,
+        },
+      ]);
+
+      setFieldsValue({
+        phoneNumber: '',
+        phoneType: '',
+      });
+    }
+  };
+
   return (
-    <Form
-      className="phone-number-form"
-      onSubmit={() => {
-        const phoneNumber = getFieldValue('phoneNumber');
-        const phoneType = getFieldValue('phoneType') || '';
-
-        if (phoneNumber !== undefined && phoneNumber.trim() !== '') {
-          setPhoneNumbers([
-            ...phoneNumbers,
-            {
-              phoneNumber,
-              phoneType,
-            },
-          ]);
-
-          setFieldsValue({
-            phoneNumber: '',
-            phoneType: '',
-          });
-        }
-      }}
-    >
+    <Form className="phone-number-form">
       <Form.Item>
         {getFieldDecorator('phoneNumber', {
           rules: [
@@ -73,8 +72,10 @@ const PhoneNumberForm = Form.create({ name: 'phoneNumber' })((props) => {
       <Button
         type="primary"
         className="form-btn"
-        htmlType="submit"
-        onClick={() => setTotalSubmitEnabled(false)}
+        onClick={() => {
+          setTotalSubmitEnabled(false);
+          onSubmit();
+        }}
       >
         Add Phone Number
       </Button>

--- a/client/src/components/ResourceReqDocsForm.jsx
+++ b/client/src/components/ResourceReqDocsForm.jsx
@@ -37,7 +37,7 @@ const StrForm = (props: FormProps) => {
   }, [getFieldValue, setListOfStrings, setFieldsValue, listOfStrings]);
 
   return (
-    <Form onSubmit={onSubmit}>
+    <Form>
       <Form.Item>
         {getFieldDecorator('requiredDocuments', {
           rules: [
@@ -52,8 +52,10 @@ const StrForm = (props: FormProps) => {
       <Button
         type="primary"
         className="form-btn"
-        htmlType="submit"
-        onClick={() => setTotalSubmitEnabled(false)}
+        onClick={() => {
+          setTotalSubmitEnabled(false);
+          onSubmit();
+        }}
       >
         Add
       </Button>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -95,7 +95,7 @@ function Login(props: Props) {
             Register Now!
           </Link>
           <Link className="form-forgot" to="/password-reset">
-            Forgot password
+            Forgot password?
           </Link>
         </Form.Item>
       </Form>

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
 import { Form } from '@ant-design/compatible';
 import '@ant-design/compatible/assets/index.css';
-import { Button, Checkbox, Input, Row, Col } from 'antd';
+import { Button, Input, Row, Col } from 'antd';
 import 'antd/dist/antd.css';
 import '../css/LoginRegister.css';
 
@@ -87,23 +87,15 @@ function Login(props: Props) {
         </Form.Item>
         <div className="red-text">{error}</div>
         <Form.Item>
-          {getFieldDecorator('remember', {
-            valuePropName: 'checked',
-            initialValue: true,
-          })(
-            <Checkbox className="form-checkbox">
-              <div className="white-text">Remember me</div>
-            </Checkbox>,
-          )}
-          <Link className="form-forgot" to="/password-reset">
-            Forgot password
-          </Link>
           <Button type="primary" htmlType="submit" className="form-button">
             Log In
           </Button>
           <div className="white-text">Don&#39;t have an account?</div>{' '}
           <Link className="link-now" to="/register">
             Register Now!
+          </Link>
+          <Link className="form-forgot" to="/password-reset">
+            Forgot password
           </Link>
         </Form.Item>
       </Form>

--- a/client/src/pages/Resources.jsx
+++ b/client/src/pages/Resources.jsx
@@ -197,7 +197,8 @@ function Resources({
         (costMap[cost].includes(resource.cost) || cost === 'Free - $$$') &&
         (resource.availableLanguages?.includes(language) ||
           language === 'All') &&
-        (resource.city === location || location === 'All / Champaign County'),
+        (resource.city.toLowerCase() === location.toLowerCase() ||
+          location === 'All / Champaign County'),
     );
 
     setFilteredResources(newFilteredResources);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1466,7 +1466,7 @@
     intl-messageformat-parser "6.4.1"
     tslib "^2.1.0"
 
-"@hack4impact-uiuc/eslint-plugin@^2.0.9":
+"@hack4impact-uiuc/eslint-plugin@^2.0.10":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@hack4impact-uiuc/eslint-plugin/-/eslint-plugin-2.0.10.tgz#d68a223141a550a861e4041de97b4d3819062465"
   integrity sha512-L8TPs1F0P/lV9vAx5tZ1QoqBPXw7ypbEVCkrEswFpILXt9e839WEUlNrMBqx6KSbOu1K0gYBKUjO5HfhkV7xDQ==


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--:construction: In development
:no_entry_sign: Do not merge
-->

## Description
This PR:
* Makes it so there's not case sensitivity when filtering by location (eg. a resource with the city of "urbana" will still show up when filtering for "Urbana")
* In the internal notes form, "false" used to show up as the subject
* Removes "Remember me?" on the login page since checking/unchecking the box didn't do anything
* Adds a loading spinner when waiting for React on switching pages rather than just text saying "Loading..."
* Fixes an issue in the admin form where clicking any sort of "Add ..." (Ex. add phone number) would result in a page refresh
     * I checked to ensure this fix didn't break anything when adding a resource - everything appears to be working as expected
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
Old login
![image](https://user-images.githubusercontent.com/32113753/109439822-8299d480-79f5-11eb-92c2-bcb10e891583.png)
New login
![image](https://user-images.githubusercontent.com/32113753/109439808-7877d600-79f5-11eb-8100-a779e4de6ac5.png)

Loading spinner
![image](https://user-images.githubusercontent.com/32113753/109439834-947b7780-79f5-11eb-8890-4273d259d1da.png)


