### PR TITLE
🏙️ Fix home css for translations

### DIFF
--- a/client/src/components/desktop/HomeDesktop.jsx
+++ b/client/src/components/desktop/HomeDesktop.jsx
@@ -65,14 +65,14 @@ export const HomeBlock1Desktop = ({
           defaultMessage="Welcome to Urbana-Champaign"
         />
         {categories && categories.length > 0 ? (
-          <Row type="flex">
+          <div className="welcome-resource-block">
             <h1 className="welcome-text-bold">
               <FormattedMessage
                 id="homeResources"
                 defaultMessage="Find Resources for"
               />
             </h1>
-            <div style={{ width: 'min-content' }}>
+            <span className="welcome-carousel-block">
               <Carousel
                 effect="fade"
                 autoplay
@@ -95,8 +95,8 @@ export const HomeBlock1Desktop = ({
                     ),
                 )}
               </Carousel>
-            </div>
-          </Row>
+            </span>
+          </div>
         ) : (
           <Row type="flex">
             <h1 className="welcome-text-bold">

--- a/client/src/components/mobile/HomeMobile.jsx
+++ b/client/src/components/mobile/HomeMobile.jsx
@@ -66,7 +66,7 @@ export const HomeBlock1Mobile = ({ backgroundImage }: Block1Props) => {
             >
               {categories.map(
                 (category) =>
-                  !category === 'Other' && (
+                  category !== 'Other' && (
                     <Link
                       to={`/resources?category=${category}`}
                       className="welcome-text-mobile-link"

--- a/client/src/css/Home.css
+++ b/client/src/css/Home.css
@@ -5,6 +5,15 @@
   opacity: 1;
 }
 
+.welcome-resource-block {
+  display: flex;
+  flex-direction: row;
+}
+
+.welcome-carousel-block {
+  flex-shrink: 2;
+}
+
 .welcome-text {
   color: #fff;
   font-weight: 400;
@@ -19,6 +28,7 @@
   font-weight: 600;
   font-size: 65px;
   line-height: 1.25;
+  white-space: nowrap;
 }
 
 .welcome-text-link {
@@ -27,6 +37,8 @@
   font-size: 65px;
   line-height: 1.25;
   padding-left: 12px;
+  width: auto;
+  display: inline-block;
 }
 
 .welcome-text-link:hover {
@@ -189,6 +201,9 @@
 
   .welcome-carousel {
     margin-bottom: 0.9em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .home-block-1 {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Fixes a few things with the home CSS to accommodate for longer category names
Also fixes a bug on mobile where category names weren't showing up
<!--
A few sentences describing the overall goals of the pull request's commits.
-->


## Screenshots
![image](https://user-images.githubusercontent.com/32113753/111395750-90a15380-868b-11eb-8600-c10b488964f7.png)

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
