### PR TITLE
✏️ Add functionality to edit resource categories

### DIFF
--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect } from 'react';
 import { EditFilled } from '@ant-design/icons';
 import { Select, Table, Tag } from 'antd';
-import { CAT_SUB_SPLITTER } from './ResourceCategorySelector';
 import { getCategories } from '../utils/api';
 
 const { Option, OptGroup } = Select;
@@ -64,34 +63,59 @@ const ManageResourcesTable = (props: Props) => {
     });
   }, []);
 
-  const displayTags = (categories, displayDropdown) => (
+  const addCategoryAndSubcategory = (selected) => {
+    const tokens = selected.split('~');
+    const cat = tokens[0];
+    const subcat = tokens[1];
+
+    // edit category and subcategory here
+  };
+
+  const displayCategoryTags = (categories) => (
     <>
       {categories.map((c) => (
         <Tag key={c} color={TAG_COLOR_DICT[c[0].toLowerCase()]}>
-          {`${c} x`}
+          {c}
         </Tag>
       ))}
-      {displayDropdown && (
-        <Select
-          placeholder="+"
-          showArrow={false}
-          style={{ width: '250px' }}
-          // onChange={onCategoryChange}
-        >
-          {fetchedCategories.map((cat) => (
-            <OptGroup key={cat.name} label={cat.name}>
-              {cat.subcategories.map((subcat) => {
-                const val = `${cat.name}${CAT_SUB_SPLITTER}${subcat}`;
-                return (
-                  <Option key={val} value={val}>
-                    {subcat}
-                  </Option>
-                );
-              })}
-            </OptGroup>
-          ))}
-        </Select>
-      )}
+    </>
+  );
+
+  const displaySubcategoryTags = (subcategories) => (
+    <>
+      {subcategories.map((c) => (
+        <Tag key={c} color={TAG_COLOR_DICT[c[0].toLowerCase()]}>
+          <span>
+            {c}
+            <t
+              onClick={() => window.location.reload()}
+              style={{ marginLeft: '5px', cursor: 'pointer' }}
+            >
+              x
+            </t>
+          </span>
+        </Tag>
+      ))}
+      <Select
+        placeholder="+"
+        showArrow={false}
+        size="small"
+        dropdownStyle={{ minWidth: '250px' }}
+        onChange={addCategoryAndSubcategory}
+      >
+        {fetchedCategories.map((cat) => (
+          <OptGroup key={cat.name} label={cat.name}>
+            {cat.subcategories.map((subcat) => {
+              const val = `${cat.name}~${subcat}`;
+              return (
+                <Option key={val} value={val}>
+                  {subcat}
+                </Option>
+              );
+            })}
+          </OptGroup>
+        ))}
+      </Select>
     </>
   );
 
@@ -126,13 +150,13 @@ const ManageResourcesTable = (props: Props) => {
     {
       title: 'Categories',
       render: function showCategories(_, resource) {
-        return displayTags(resource.categories, false);
+        return displayCategoryTags(resource.categories);
       },
     },
     {
       title: 'Subcategories',
       render: function showSubcategories(_, resource) {
-        return displayTags(resource.subcategories, true);
+        return displaySubcategoryTags(resource.subcategories);
       },
     },
     {

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -68,7 +68,7 @@ const ManageResourcesTable = (props: Props) => {
     <>
       {categories.map((c) => (
         <Tag key={c} color={TAG_COLOR_DICT[c[0].toLowerCase()]}>
-          {c}
+          {`${c} x`}
         </Tag>
       ))}
       {displayDropdown && (

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -70,7 +70,7 @@ const ManageResourcesTable = (props: Props) => {
     });
   }, []);
 
-  const updateCategories = (selectedValues, resource) => {
+  const updateCategories = async (selectedValues, resource) => {
     const newCategories = [];
     const newSubcategories = [];
     selectedValues.forEach((selected) => {
@@ -78,9 +78,8 @@ const ManageResourcesTable = (props: Props) => {
       newCategories.push(tokens[0]);
       newSubcategories.push(tokens[1]);
     });
-    editResourceCategories(resource.id, newCategories, newSubcategories);
-    updateView();
-    // window.location.reload();
+    await editResourceCategories(resource.id, newCategories, newSubcategories);
+    await updateView();
   };
 
   const displayCategoryTags = (categories) => (

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -63,12 +63,18 @@ const ManageResourcesTable = (props: Props) => {
     });
   }, []);
 
-  const addCategoryAndSubcategory = (selected) => {
+  const addCategoryAndSubcategory = (selected, resource) => {
     const tokens = selected.split('~');
-    const cat = tokens[0];
-    const subcat = tokens[1];
+    const newCategories = resource.categories.push(tokens[0]);
+    const newSubcategories = resource.subcategories.push(tokens[1]);
+    // editResourceCategories(resource.id, newCategories, newSubcategories);
+  };
 
-    // edit category and subcategory here
+  const removeCategoryAndSubcategory = (selected, resource) => {
+    const idx = resource.subcategories.indexOf(selected);
+    const newCategories = resource.categories.splice(idx, 1);
+    const newSubcategories = resource.subcategories.splice(idx, 1);
+    // editResourceCategories(resource.id, newCategories, newSubcategories);
   };
 
   const displayCategoryTags = (categories) => (
@@ -81,14 +87,14 @@ const ManageResourcesTable = (props: Props) => {
     </>
   );
 
-  const displaySubcategoryTags = (subcategories) => (
+  const displaySubcategoryTags = (resource) => (
     <>
-      {subcategories.map((c) => (
+      {resource.subcategories.map((c) => (
         <Tag key={c} color={TAG_COLOR_DICT[c[0].toLowerCase()]}>
           <span>
             {c}
             <t
-              onClick={() => window.location.reload()}
+              onClick={() => removeCategoryAndSubcategory(c, resource)}
               style={{ marginLeft: '5px', cursor: 'pointer' }}
             >
               x
@@ -101,7 +107,7 @@ const ManageResourcesTable = (props: Props) => {
         showArrow={false}
         size="small"
         dropdownStyle={{ minWidth: '250px' }}
-        onChange={addCategoryAndSubcategory}
+        onChange={(e) => addCategoryAndSubcategory(e, resource)}
       >
         {fetchedCategories.map((cat) => (
           <OptGroup key={cat.name} label={cat.name}>
@@ -156,7 +162,7 @@ const ManageResourcesTable = (props: Props) => {
     {
       title: 'Subcategories',
       render: function showSubcategories(_, resource) {
-        return displaySubcategoryTags(resource.subcategories);
+        return displaySubcategoryTags(resource);
       },
     },
     {

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { EditFilled } from '@ant-design/icons';
 import { Select, Table, Tag } from 'antd';
-import { getCategories } from '../utils/api';
+import { getCategories, editResourceCategories } from '../utils/api';
 
 const { Option, OptGroup } = Select;
 
@@ -61,26 +61,30 @@ const ManageResourcesTable = (props: Props) => {
         }
       }
     });
-  }, []);
+  }, [fetchedCategories]);
 
   const addCategoryAndSubcategory = (selected, resource) => {
     const tokens = selected.split('~');
-    const newCategories = resource.categories.push(tokens[0]);
-    const newSubcategories = resource.subcategories.push(tokens[1]);
-    // editResourceCategories(resource.id, newCategories, newSubcategories);
+    const newCategories = resource.categories;
+    const newSubcategories = resource.subcategories;
+    newCategories.push(tokens[0]);
+    newSubcategories.push(tokens[1]);
+    editResourceCategories(resource.id, newCategories, newSubcategories);
   };
 
   const removeCategoryAndSubcategory = (selected, resource) => {
     const idx = resource.subcategories.indexOf(selected);
-    const newCategories = resource.categories.splice(idx, 1);
-    const newSubcategories = resource.subcategories.splice(idx, 1);
-    // editResourceCategories(resource.id, newCategories, newSubcategories);
+    const newCategories = resource.categories;
+    const newSubcategories = resource.subcategories;
+    newCategories.splice(idx, 1);
+    newSubcategories.splice(idx, 1);
+    editResourceCategories(resource.id, newCategories, newSubcategories);
   };
 
   const displayCategoryTags = (categories) => (
     <>
       {categories.map((c) => (
-        <Tag key={c} color={CATEGORY_COLOR_DICT[c[0].toLowerCase()]}>
+        <Tag key={c} color={CATEGORY_COLOR_DICT[c[0]?.toLowerCase()]}>
           {c}
         </Tag>
       ))}
@@ -92,7 +96,9 @@ const ManageResourcesTable = (props: Props) => {
       {resource.subcategories.map((c, idx) => (
         <Tag
           key={c}
-          color={CATEGORY_COLOR_DICT[resource.categories[idx][0].toLowerCase()]}
+          color={
+            CATEGORY_COLOR_DICT[resource.categories[idx][0]?.toLowerCase()]
+          }
         >
           <span>
             {c}
@@ -109,7 +115,7 @@ const ManageResourcesTable = (props: Props) => {
         placeholder="+"
         showArrow={false}
         size="small"
-        dropdownStyle={{ minWidth: '250px' }}
+        dropdownMatchSelectWidth={false}
         onChange={(e) => addCategoryAndSubcategory(e, resource)}
       >
         {fetchedCategories.map((cat) => (

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -96,6 +96,7 @@ const ManageResourcesTable = (props: Props) => {
     const { label, value, closable, onClose } = tagProps;
     const tokens = value.split('~');
     const idx = resource.subcategories.indexOf(tokens[1]);
+
     return (
       <Tag
         color={
@@ -114,13 +115,13 @@ const ManageResourcesTable = (props: Props) => {
   const displaySubcategoryTags = (resource) => (
     <Select
       mode="multiple"
-      defaultValue={resource.categoryPairs}
       dropdownMatchSelectWidth={false}
       bordered={false}
       showArrow
       style={{ width: '100%' }}
       onChange={(e) => updateCategories(e, resource)}
       tagRender={(tagProps) => subcategoryTag(tagProps, resource)}
+      value={resource.categoryPairs}
     >
       {fetchedCategories.map((cat) => (
         <OptGroup key={cat.name} label={cat.name}>

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -7,27 +7,27 @@ import { getCategories } from '../utils/api';
 
 const { Option, OptGroup } = Select;
 
-const TAG_COLOR_DICT = {
+const CATEGORY_COLOR_DICT = {
   a: 'blue',
   b: 'gold',
-  c: 'red',
+  c: 'volcano',
   d: 'volcano',
   e: 'green',
-  f: 'geekblue',
+  f: 'magenta',
   g: 'orange',
   h: 'cyan',
   i: 'magenta',
   j: 'gold',
   k: 'purple',
-  l: 'purple',
+  l: 'orange',
   m: 'green',
   n: 'green',
-  o: 'blue',
+  o: 'purple',
   p: 'cyan',
   q: 'blue',
   r: 'blue',
   s: 'geekblue',
-  t: 'geekblue',
+  t: 'volcano',
   u: 'purple',
   v: 'purple',
   w: 'purple',
@@ -80,7 +80,7 @@ const ManageResourcesTable = (props: Props) => {
   const displayCategoryTags = (categories) => (
     <>
       {categories.map((c) => (
-        <Tag key={c} color={TAG_COLOR_DICT[c[0].toLowerCase()]}>
+        <Tag key={c} color={CATEGORY_COLOR_DICT[c[0].toLowerCase()]}>
           {c}
         </Tag>
       ))}
@@ -89,8 +89,11 @@ const ManageResourcesTable = (props: Props) => {
 
   const displaySubcategoryTags = (resource) => (
     <>
-      {resource.subcategories.map((c) => (
-        <Tag key={c} color={TAG_COLOR_DICT[c[0].toLowerCase()]}>
+      {resource.subcategories.map((c, idx) => (
+        <Tag
+          key={c}
+          color={CATEGORY_COLOR_DICT[resource.categories[idx][0].toLowerCase()]}
+        >
           <span>
             {c}
             <t
@@ -156,7 +159,7 @@ const ManageResourcesTable = (props: Props) => {
     {
       title: 'Categories',
       render: function showCategories(_, resource) {
-        return displayCategoryTags(resource.categories);
+        return displayCategoryTags([...new Set(resource.categories)]);
       },
     },
     {

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -44,6 +44,7 @@ type Props = {
     description: string,
     categories: Array<string>,
     subcategories: Array<string>,
+    categoryPairs: Array<string>,
     id: string,
   }>,
 };
@@ -62,6 +63,17 @@ const ManageResourcesTable = (props: Props) => {
       }
     });
   }, [fetchedCategories]);
+
+  const updateCategories = (selectedValues, resource) => {
+    const newCategories = [];
+    const newSubcategories = [];
+    selectedValues.forEach((selected) => {
+      const tokens = selected.split('~');
+      newCategories.push(tokens[0]);
+      newSubcategories.push(tokens[1]);
+    });
+    editResourceCategories(resource.id, newCategories, newSubcategories);
+  };
 
   const addCategoryAndSubcategory = (selected, resource) => {
     const tokens = selected.split('~');
@@ -118,6 +130,14 @@ const ManageResourcesTable = (props: Props) => {
         dropdownMatchSelectWidth={false}
         onChange={(e) => addCategoryAndSubcategory(e, resource)}
       >
+        {/* <Select
+        mode="multiple"
+        defaultValue={resource.categoryPairs}
+        dropdownMatchSelectWidth={false}
+        bordered={false}
+        style={{ width: '100%' }}
+        onChange={(e) => updateCategories(e, resource)}
+      > */}
         {fetchedCategories.map((cat) => (
           <OptGroup key={cat.name} label={cat.name}>
             {cat.subcategories.map((subcat) => {

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -47,10 +47,16 @@ type Props = {
     categoryPairs: Array<string>,
     id: string,
   }>,
+  updateView: () => void,
 };
 
 const ManageResourcesTable = (props: Props) => {
-  const { selectedCategory, selectedSubcategory, resources } = props;
+  const {
+    selectedCategory,
+    selectedSubcategory,
+    resources,
+    updateView,
+  } = props;
 
   const [fetchedCategories, setFetchedCategories] = useState([]);
 
@@ -62,7 +68,7 @@ const ManageResourcesTable = (props: Props) => {
         }
       }
     });
-  }, [fetchedCategories]);
+  }, []);
 
   const updateCategories = (selectedValues, resource) => {
     const newCategories = [];
@@ -73,24 +79,8 @@ const ManageResourcesTable = (props: Props) => {
       newSubcategories.push(tokens[1]);
     });
     editResourceCategories(resource.id, newCategories, newSubcategories);
-  };
-
-  const addCategoryAndSubcategory = (selected, resource) => {
-    const tokens = selected.split('~');
-    const newCategories = resource.categories;
-    const newSubcategories = resource.subcategories;
-    newCategories.push(tokens[0]);
-    newSubcategories.push(tokens[1]);
-    editResourceCategories(resource.id, newCategories, newSubcategories);
-  };
-
-  const removeCategoryAndSubcategory = (selected, resource) => {
-    const idx = resource.subcategories.indexOf(selected);
-    const newCategories = resource.categories;
-    const newSubcategories = resource.subcategories;
-    newCategories.splice(idx, 1);
-    newSubcategories.splice(idx, 1);
-    editResourceCategories(resource.id, newCategories, newSubcategories);
+    updateView();
+    // window.location.reload();
   };
 
   const displayCategoryTags = (categories) => (
@@ -103,55 +93,49 @@ const ManageResourcesTable = (props: Props) => {
     </>
   );
 
-  const displaySubcategoryTags = (resource) => (
-    <>
-      {resource.subcategories.map((c, idx) => (
-        <Tag
-          key={c}
-          color={
-            CATEGORY_COLOR_DICT[resource.categories[idx][0]?.toLowerCase()]
-          }
-        >
-          <span>
-            {c}
-            <t
-              onClick={() => removeCategoryAndSubcategory(c, resource)}
-              style={{ marginLeft: '5px', cursor: 'pointer' }}
-            >
-              x
-            </t>
-          </span>
-        </Tag>
-      ))}
-      <Select
-        placeholder="+"
-        showArrow={false}
-        size="small"
-        dropdownMatchSelectWidth={false}
-        onChange={(e) => addCategoryAndSubcategory(e, resource)}
+  const subcategoryTag = (tagProps, resource) => {
+    const { label, value, closable, onClose } = tagProps;
+    const tokens = value.split('~');
+    const idx = resource.subcategories.indexOf(tokens[1]);
+    return (
+      <Tag
+        color={
+          resource.categories[idx]
+            ? CATEGORY_COLOR_DICT[resource.categories[idx][0]?.toLowerCase()]
+            : 'white'
+        }
+        closable={closable}
+        onClose={onClose}
       >
-        {/* <Select
-        mode="multiple"
-        defaultValue={resource.categoryPairs}
-        dropdownMatchSelectWidth={false}
-        bordered={false}
-        style={{ width: '100%' }}
-        onChange={(e) => updateCategories(e, resource)}
-      > */}
-        {fetchedCategories.map((cat) => (
-          <OptGroup key={cat.name} label={cat.name}>
-            {cat.subcategories.map((subcat) => {
-              const val = `${cat.name}~${subcat}`;
-              return (
-                <Option key={val} value={val}>
-                  {subcat}
-                </Option>
-              );
-            })}
-          </OptGroup>
-        ))}
-      </Select>
-    </>
+        {label}
+      </Tag>
+    );
+  };
+
+  const displaySubcategoryTags = (resource) => (
+    <Select
+      mode="multiple"
+      defaultValue={resource.categoryPairs}
+      dropdownMatchSelectWidth={false}
+      bordered={false}
+      showArrow
+      style={{ width: '100%' }}
+      onChange={(e) => updateCategories(e, resource)}
+      tagRender={(tagProps) => subcategoryTag(tagProps, resource)}
+    >
+      {fetchedCategories.map((cat) => (
+        <OptGroup key={cat.name} label={cat.name}>
+          {cat.subcategories.map((subcat) => {
+            const val = `${cat.name}~${subcat}`;
+            return (
+              <Option key={val} value={val}>
+                {subcat}
+              </Option>
+            );
+          })}
+        </OptGroup>
+      ))}
+    </Select>
   );
 
   const filterResources = (resource) =>

--- a/client/src/components/ResourceCategorySelector.jsx
+++ b/client/src/components/ResourceCategorySelector.jsx
@@ -54,7 +54,6 @@ const CategorySelector = (props: Props) => {
     });
   };
 
-  // fetch categories && subcategories
   useEffect(() => {
     getCategories().then((res) => {
       if (res !== null) {

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -157,8 +157,8 @@ const ResourceManager = () => {
         newResources.push({
           name: r.name,
           description: r.description,
-          categories: [...new Set(r.category)],
-          subcategories: [...new Set(r.subcategory)],
+          categories: r.category,
+          subcategories: r.subcategory,
           id: r._id.toString(),
         });
       });

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -129,6 +129,7 @@ const ResourceManager = () => {
       description: string,
       categories: Array<string>,
       subcategories: Array<string>,
+      categoryPairs: Array<string>,
       id: string,
     }>,
   >([]);
@@ -151,11 +152,15 @@ const ResourceManager = () => {
     const newResources = [];
     if (res != null) {
       res.result.forEach((r) => {
+        const pairs = r.subcategory.map(
+          (subcat, idx) => `${r.category[idx]}~${subcat}`,
+        );
         newResources.push({
           name: r.name,
           description: r.description,
           categories: r.category,
           subcategories: r.subcategory,
+          categoryPairs: pairs,
           id: r._id.toString(),
         });
       });

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -208,6 +208,8 @@ const ResourceManager = () => {
           selectedCategory={selectedCategory}
           selectedSubcategory={selectedSubcategory}
           resources={resources}
+          updateView={updateView}
+          // fetchResources={fetchResource}
         />
       </div>
     </div>

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -163,7 +163,6 @@ const ResourceManager = () => {
         });
       });
     }
-    console.log(newResources);
     setResources(newResources);
   };
 

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -71,39 +71,36 @@ const SidebarCategory = (props: Props) => {
       }
       onTitleClick={handleChange}
     >
-      {categories[categoryName][0].map((subcategory) => {
-        console.log(categories, categoryName);
-        return (
-          <Menu.Item
-            key={subcategory}
-            className="resource-manager-sidebar-category"
-            onClick={() => {
-              setSelectedSubcategory(subcategory);
-              setSelectedCategory(categoryName);
-            }}
-          >
-            {subcategory}
-            <div>
-              <EditCategoryModal
-                modalType="rename"
-                categoryType="subcategory"
-                subcategoryName={subcategory}
-                id={categories[categoryName][1]}
-                categoryName={categoryName}
-                updateView={updateView}
-              />
-              <EditCategoryModal
-                modalType="delete"
-                categoryType="subcategory"
-                subcategoryName={subcategory}
-                id={categories[categoryName][1]}
-                categoryName={categoryName}
-                updateView={updateView}
-              />
-            </div>
-          </Menu.Item>
-        );
-      })}
+      {categories[categoryName][0].map((subcategory) => (
+        <Menu.Item
+          key={subcategory}
+          className="resource-manager-sidebar-category"
+          onClick={() => {
+            setSelectedSubcategory(subcategory);
+            setSelectedCategory(categoryName);
+          }}
+        >
+          {subcategory}
+          <div>
+            <EditCategoryModal
+              modalType="rename"
+              categoryType="subcategory"
+              subcategoryName={subcategory}
+              id={categories[categoryName][1]}
+              categoryName={categoryName}
+              updateView={updateView}
+            />
+            <EditCategoryModal
+              modalType="delete"
+              categoryType="subcategory"
+              subcategoryName={subcategory}
+              id={categories[categoryName][1]}
+              categoryName={categoryName}
+              updateView={updateView}
+            />
+          </div>
+        </Menu.Item>
+      ))}
       <Menu.Item
         key={categories[categoryName][1].toString().concat('-add-subcategory')}
         className="resource-manager-sidebar-category"

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -209,7 +209,6 @@ const ResourceManager = () => {
           selectedSubcategory={selectedSubcategory}
           resources={resources}
           updateView={updateView}
-          // fetchResources={fetchResource}
         />
       </div>
     </div>

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -14,9 +14,9 @@ import type {
 import type { ApiResponse } from '../types/apiResponse';
 
 const instance = axios.create({
-  baseURL: 'https://nawc-staging.vercel.app',
+  // baseURL: 'https://nawc-staging.vercel.app',
   // For testing on dev database:
-  // baseURL: 'http://localhost:9000',
+  baseURL: 'http://localhost:9000',
 });
 
 export const imageToLink = (

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -14,9 +14,9 @@ import type {
 import type { ApiResponse } from '../types/apiResponse';
 
 const instance = axios.create({
-  // baseURL: 'https://nawc-staging.vercel.app',
+  baseURL: 'https://nawc-staging.vercel.app',
   // For testing on dev database:
-  baseURL: 'http://localhost:9000',
+  // baseURL: 'http://localhost:9000',
 });
 
 export const imageToLink = (


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
* Subcategory tag colors coincide with respective category color
* Add functionality to remove/edit subcategories. Categories reflect changes as well.
  * Tried a bunch of edge cases and they work (trust me) 
  * Very dependent on the structure of categories/subcategories. I'm assuming `len(categories) === len(subcategories)` and that each index is basically a tuple (so `categories[3]` and `subcategories[3]` are a pair).
  * Categories and subcategories can be duplicated. Duplicate categories won't be shown (since each category can have multiple subcategories). Duplicate subcategories will be shown (so you can prune them).

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Resolves #357 
Resolves #380 

![image](https://user-images.githubusercontent.com/36244017/113659781-60d0e480-9668-11eb-9967-42c7e77a609f.png)
