### PR TITLE
👋🏽 Change resource grid responsive numbers

### DIFF
--- a/client/src/components/ResourcesGrid.jsx
+++ b/client/src/components/ResourcesGrid.jsx
@@ -13,10 +13,10 @@ function ResourcesGrid(props) {
         gutter: [32, 16],
         xs: 1,
         sm: 2,
-        md: 4,
-        lg: 4,
-        xl: 6,
-        xxl: 3,
+        md: 3,
+        lg: 3,
+        xl: 4,
+        xxl: 4,
       }}
       dataSource={filteredResources}
       renderItem={(resource) => (


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready
<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Before the number of resources displayed per row for some monitor sizes was wonky, this makes it better
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
![image](https://user-images.githubusercontent.com/32113753/114059933-7c034600-985a-11eb-8356-fce752aa575f.png)
![image](https://user-images.githubusercontent.com/32113753/114059963-86254480-985a-11eb-9d12-dcbb02a78cd8.png)
