### PR TITLE
🦸🏾 Ensure one category can be open at a time in resource manager

### DIFF
--- a/api/src/api/admin.js
+++ b/api/src/api/admin.js
@@ -543,4 +543,68 @@ router.get(
   }),
 );
 
+// Report a translation error for an ID
+router.patch(
+  '/report/:id',
+  errorWrap(async (req, res) => {
+    const { id } = req.params;
+    const { language, type } = req.query;
+
+    const updateQuery = { $inc: { numReports: 1 } };
+
+    switch (type) {
+      case 'resource':
+        await VerifiedTranslation.updateOne(
+          {
+            resourceID: id,
+            language,
+          },
+          updateQuery,
+        );
+        break;
+      case 'category':
+        await VerifiedTranslation.updateOne(
+          {
+            categoryID: id,
+            language,
+          },
+          updateQuery,
+        );
+        break;
+      case 'subcategory':
+        await VerifiedTranslation.updateOne(
+          {
+            subcategoryID: id,
+            language,
+          },
+          updateQuery,
+        );
+        break;
+      case 'testimonial':
+        await VerifiedTranslation.updateOne(
+          {
+            testimonialID: id,
+            language,
+          },
+          updateQuery,
+        );
+        break;
+      default:
+        res.json({
+          code: 400,
+          message: 'Could not find specified type',
+          success: false,
+          result: null,
+        });
+    }
+
+    res.json({
+      code: 200,
+      message: 'Successfully reported an error',
+      success: true,
+      result: null,
+    });
+  }),
+);
+
 module.exports = router;

--- a/client/src/components/ManageResourcesTable.jsx
+++ b/client/src/components/ManageResourcesTable.jsx
@@ -133,6 +133,7 @@ const ManageResourcesTable = (props: Props) => {
 
   const filterResources = (resource) =>
     !selectedCategory ||
+    selectedCategory === 'All Resources' ||
     (!selectedSubcategory && resource.categories.includes(selectedCategory)) ||
     (resource.categories.includes(selectedCategory) &&
       resource.subcategories.includes(selectedSubcategory));

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -30,15 +30,6 @@ const SidebarCategory = (props: Props) => {
   } = props;
   const [opened, setOpened] = useState(false);
 
-  const handleChange = () => {
-    setOpened(!opened);
-    if (!opened) setSelectedCategory(categoryName);
-    else {
-      setSelectedCategory('');
-      setSelectedSubcategory('');
-    }
-  };
-
   return (
     <SubMenu
       {...props}
@@ -70,7 +61,6 @@ const SidebarCategory = (props: Props) => {
           <DownOutlined style={{ position: 'relative', top: -2 }} />
         )
       }
-      onTitleClick={handleChange}
     >
       {categories[categoryName][0].map((subcategory) => (
         <Menu.Item
@@ -138,6 +128,7 @@ const ResourceManager = () => {
   >([]);
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedSubcategory, setSelectedSubcategory] = useState('');
+  const [openKeys, setOpenKeys] = useState<Array<string>>([]);
 
   const fetchCategories = async () => {
     const res = await getCategories();
@@ -179,10 +170,56 @@ const ResourceManager = () => {
     updateView();
   }, [updateView]);
 
+  const onOpenChange = (newOpenKeys: Array<string>) => {
+    if (newOpenKeys.length === 0) {
+      if (categories[category].some((sub) => sub.name === subcategory)) {
+        history.push({
+          pathname: '/resources',
+          search: `?category=${category}`,
+        });
+        return;
+      }
+      setOpenKeys([]);
+      return;
+    }
+
+    const latestOpenKey = newOpenKeys.find(
+      (key) => openKeys.indexOf(key) === -1,
+    );
+    if (Object.keys(categories).indexOf(latestOpenKey) === -1) {
+      setOpenKeys(newOpenKeys);
+    } else {
+      setOpenKeys(latestOpenKey != null ? [latestOpenKey] : []);
+    }
+    const categorySelected = latestOpenKey;
+    history.push({
+      pathname: '/resources',
+      search: `?category=${categorySelected ?? ''}`,
+    });
+  };
+
+  // const onOpenChange = (e) => {
+  //   console.log(e);
+  //   setOpened(!opened);
+  //   if (!opened) setSelectedCategory(categoryName);
+  //   else {
+  //     setSelectedCategory('');
+  //     setSelectedSubcategory('');
+  //   }
+  // };
+
   return (
     <div className="resource-manager-flexbox">
       <div className="resource-manager-sidebar">
-        <Menu mode="inline" expandIcon={<div />}>
+        <Menu
+          mode="inline"
+          selectedKeys={
+            selectedSubcategory === '' ? selectedCategory : selectedSubcategory
+          }
+          openKeys={openKeys}
+          onOpenChange={onOpenChange}
+          expandIcon={<div />}
+        >
           {Object.keys(categories).map((categoryName) => (
             <SidebarCategory
               categories={categories}

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -12,24 +12,26 @@ import ManageResourcesTable from './ManageResourcesTable';
 import '../css/ResourceManager.css';
 import EditCategoryModal from './EditCategoryModal';
 
+const { SubMenu } = Menu;
+
 type Props = {
   categories: { [string]: [Array<Subcategory>, number] },
   categoryName: string,
+  isOpen: boolean,
+  setSelectedCategory: (string) => void,
+  setSelectedSubcategory: (string) => void,
   updateView: () => void,
 };
 
 const SidebarCategory = (props: Props) => {
-  const { SubMenu } = Menu;
-
   const {
     categories,
     categoryName,
+    isOpen,
     setSelectedCategory,
     setSelectedSubcategory,
     updateView,
   } = props;
-  const [opened, setOpened] = useState(false);
-
   return (
     <SubMenu
       {...props}
@@ -55,7 +57,7 @@ const SidebarCategory = (props: Props) => {
         </span>
       }
       icon={
-        opened ? (
+        isOpen ? (
           <UpOutlined style={{ position: 'relative', top: -2 }} />
         ) : (
           <DownOutlined style={{ position: 'relative', top: -2 }} />
@@ -64,7 +66,7 @@ const SidebarCategory = (props: Props) => {
     >
       {categories[categoryName][0].map((subcategory) => (
         <Menu.Item
-          key={subcategory._id}
+          key={subcategory.name}
           className="resource-manager-sidebar-category"
           onClick={() => {
             setSelectedSubcategory(subcategory.name);
@@ -126,7 +128,7 @@ const ResourceManager = () => {
       id: string,
     }>,
   >([]);
-  const [selectedCategory, setSelectedCategory] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('All Resources');
   const [selectedSubcategory, setSelectedSubcategory] = useState('');
   const [openKeys, setOpenKeys] = useState<Array<string>>([]);
 
@@ -171,14 +173,10 @@ const ResourceManager = () => {
   }, [updateView]);
 
   const onOpenChange = (newOpenKeys: Array<string>) => {
+    console.log(newOpenKeys);
     if (newOpenKeys.length === 0) {
-      if (categories[category].some((sub) => sub.name === subcategory)) {
-        history.push({
-          pathname: '/resources',
-          search: `?category=${category}`,
-        });
-        return;
-      }
+      setSelectedCategory('All Resources');
+      setSelectedSubcategory('');
       setOpenKeys([]);
       return;
     }
@@ -191,22 +189,15 @@ const ResourceManager = () => {
     } else {
       setOpenKeys(latestOpenKey != null ? [latestOpenKey] : []);
     }
-    const categorySelected = latestOpenKey;
-    history.push({
-      pathname: '/resources',
-      search: `?category=${categorySelected ?? ''}`,
-    });
+    setSelectedCategory(latestOpenKey);
+    setSelectedSubcategory('');
   };
 
-  // const onOpenChange = (e) => {
-  //   console.log(e);
-  //   setOpened(!opened);
-  //   if (!opened) setSelectedCategory(categoryName);
-  //   else {
-  //     setSelectedCategory('');
-  //     setSelectedSubcategory('');
-  //   }
-  // };
+  const categorySelectAll = () => {
+    setSelectedCategory('All Resources');
+    setSelectedSubcategory('');
+    setOpenKeys([]);
+  };
 
   return (
     <div className="resource-manager-flexbox">
@@ -220,11 +211,15 @@ const ResourceManager = () => {
           onOpenChange={onOpenChange}
           expandIcon={<div />}
         >
+          <Menu.Item key="All Resources" onClick={categorySelectAll}>
+            All Resources
+          </Menu.Item>
           {Object.keys(categories).map((categoryName) => (
             <SidebarCategory
               categories={categories}
               categoryName={categoryName}
               key={categoryName}
+              isOpen={categoryName === selectedCategory}
               updateView={updateView}
               setSelectedCategory={setSelectedCategory}
               setSelectedSubcategory={setSelectedSubcategory}

--- a/client/src/components/ResourceManager.jsx
+++ b/client/src/components/ResourceManager.jsx
@@ -173,7 +173,6 @@ const ResourceManager = () => {
   }, [updateView]);
 
   const onOpenChange = (newOpenKeys: Array<string>) => {
-    console.log(newOpenKeys);
     if (newOpenKeys.length === 0) {
       setSelectedCategory('All Resources');
       setSelectedSubcategory('');


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:
:rocket: Ready

<!--
:construction: In development
:no_entry_sign: Do not merge
-->

## Description
Adds "all resources" to resource manager, ensures only one category can be open at a time
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #383 
## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
![image](https://user-images.githubusercontent.com/32113753/116171291-1a523100-a6ce-11eb-8f74-ed111eeb69b6.png)
